### PR TITLE
feat: sort projects select options by preferred order

### DIFF
--- a/src/components/Toolbar/ExampleList.tsx
+++ b/src/components/Toolbar/ExampleList.tsx
@@ -1,10 +1,13 @@
 import type { ChangeEvent, FC } from "react";
 import { demos } from "../../data/demos";
+import type { Example } from "../../data/demos";
 import { useProject } from "../../features/Projects/stores/useProject";
+import { sortEntries } from "../ProjectBrowser/SortBy";
 
 const ExampleList: FC = () => {
     const {
         getSavedProjects,
+        getProjectMetadata,
         loadProject,
         createNewProjectFromDemo,
         currentSelection,
@@ -23,6 +26,19 @@ const ExampleList: FC = () => {
         }
     };
 
+    const getSortedProjects = (mode: "pj" | "ex") => (
+        getSavedProjects(mode)
+            .map(p => getProjectMetadata(p) as Example)
+            .sort((a, b) =>
+                sortEntries(
+                    "latest",
+                    mode == "pj" ? "Projects" : "Examples",
+                    a,
+                    b,
+                )
+            )
+    );
+
     return (
         <div className="join border border-base-100">
             <select
@@ -34,9 +50,9 @@ const ExampleList: FC = () => {
                     My Projects
                 </option>
 
-                {getSavedProjects("pj").map((project) => (
-                    <option key={project} value={project}>
-                        {project.replace("pj-", "")}
+                {getSortedProjects("pj").map((project) => (
+                    <option key={project.name} value={project.name}>
+                        {project.formattedName}
                     </option>
                 ))}
 
@@ -44,19 +60,24 @@ const ExampleList: FC = () => {
                     My Examples
                 </option>
 
-                {getSavedProjects("ex").map((project) => (
-                    <option key={project} value={project}>
-                        {project.replace("ex-", "")}
+                {getSortedProjects("ex").map((project) => (
+                    <option key={project.name} value={project.name}>
+                        {project.formattedName}
                     </option>
                 ))}
 
                 <option className="text-md" disabled>KAPLAY Demos</option>
 
-                {demos.map((example) => (
-                    <option key={example.name} data-example-id={example.id}>
-                        {example.name}
-                    </option>
-                ))}
+                {demos.sort((a, b) => sortEntries("topic", "Examples", a, b))
+                    .map((example) => (
+                        <option
+                            key={example.name}
+                            value={example.name}
+                            data-example-id={example.id}
+                        >
+                            {example.formattedName}
+                        </option>
+                    ))}
             </select>
             <button
                 className="join-item | btn btn-xs"


### PR DESCRIPTION
Sort projects select options by preferred order:
- Own Projects and Examples by `"latest"` (`updatedAt`)
- KAPLAY Demos/Examples by `"topic"` (`sortName` _category_-_group_-_name_)

Includes options text changed from fileName to formattedName.